### PR TITLE
fix continuation line over-indented

### DIFF
--- a/csmpe/core_plugins/csm_install_operations/ios_xe/activate.py
+++ b/csmpe/core_plugins/csm_install_operations/ios_xe/activate.py
@@ -152,8 +152,8 @@ class Plugin(CSMPlugin):
                 if m:
                     image_type = m.group(1)
                     if image_type not in pkg:
-                        self.ctx.warning('The post-activate image type: {} while Activate package = '
-                                       '{}'.format(image_type, pkg))
+                        self.ctx.warning('The post-activate image type: {} while Activate '
+                                         'package = {}'.format(image_type, pkg))
                 else:
                     activate_success = False
                     self.ctx.info('show version = {}'.format(output))

--- a/csmpe/core_plugins/csm_install_operations/ios_xe/pre_activate.py
+++ b/csmpe/core_plugins/csm_install_operations/ios_xe/pre_activate.py
@@ -84,8 +84,7 @@ class Plugin(CSMPlugin):
             self.ctx.info("Private device image: {}".format(pkg))
 
         if pkg_family not in supported_imgs[device_family]:
-            self.ctx.info("Private device image: {} on {}".
-                           format(pkg, self.ctx._connection.platform))
+            self.ctx.info("Private device image: {} on {}".format(pkg, self.ctx._connection.platform))
 
         # check the RSP type between image and device:
         curr_rsp = None


### PR DESCRIPTION
fix the following two lines:
csmpe/core_plugins/csm_install_operations/ios_xe/activate.py:156:40: E128 continuation line under-indented for visual indent
csmpe/core_plugins/csm_install_operations/ios_xe/pre_activate.py:88:28: E127 continuation line over-indented for visual indent
