### PR TITLE
Issues # 60 and 64

### DIFF
--- a/csmpe/core_plugins/csm_filesystem_check/ios_xr/filesystem_rw_check.py
+++ b/csmpe/core_plugins/csm_filesystem_check/ios_xr/filesystem_rw_check.py
@@ -37,7 +37,7 @@ class Plugin(CSMPlugin):
     name = "Filesystem Check Plugin"
     platforms = {'ASR9K', 'CRS'}
     phases = {'Pre-Upgrade'}
-    os = {'XR'}
+    os = {'None'}
 
     def _can_create_dir(self, filesystem):
 

--- a/csmpe/core_plugins/csm_node_status_check/ios_xe/plugin.py
+++ b/csmpe/core_plugins/csm_node_status_check/ios_xe/plugin.py
@@ -33,6 +33,7 @@ class Plugin(CSMPlugin):
     name = "Node Status Check Plugin"
     platforms = {'ASR900'}
     phases = {'Pre-Upgrade', 'Post-Upgrade'}
+    os = {'XE'}
 
     def run(self):
         # show platform can take more than 1 minute after router reload. Issue No. 47


### PR DESCRIPTION
1. Disable csm_filesystem_check/filesystem_rw_check for IOS-XR.
2. Disable csm_node_status_check/show platform for IOS (ASR901).