### PR TITLE
fix issue #69 show platform parsing

### DIFF
--- a/csmpe/core_plugins/csm_node_status_check/exr/plugin_lib.py
+++ b/csmpe/core_plugins/csm_node_status_check/exr/plugin_lib.py
@@ -183,7 +183,7 @@ def parse_show_platform(ctx, output):
 
         if line[0].isdigit():
             node = line[:dl["type"]]
-            if not re.search('CPU\d+$', node):
+            if not re.search('CPU\d+\s*$', node):
                 continue
 
             node_type = line[dl['type']:dl['state']]


### PR DESCRIPTION
change re.search('CPU\d+\s*$', node) from re.search('CPU\d+$', node)