### PR TITLE
fix issue #79

### DIFF
--- a/csmpe/core_plugins/csm_install_operations/exr/install.py
+++ b/csmpe/core_plugins/csm_install_operations/exr/install.py
@@ -199,7 +199,7 @@ def wait_for_reload(ctx):
         ctx.post_status("Waiting for device boot to reconnect")
         ctx.info("Waiting for device boot to reconnect")
         time.sleep(60)
-        ctx.reconnect(max_timeout=1500, force_discovery=True)  # 25 * 60 = 1500
+        ctx.reconnect(max_timeout=3600, force_discovery=True)  # 60 * 60 = 3600
 
     else:
         ctx.info("Keeping console connected")

--- a/csmpe/core_plugins/csm_install_operations/ios_xr/install.py
+++ b/csmpe/core_plugins/csm_install_operations/ios_xr/install.py
@@ -142,7 +142,7 @@ def wait_for_reload(ctx):
         ctx.post_status("Waiting for device boot to reconnect")
         ctx.info("Waiting for device boot to reconnect")
         time.sleep(60)
-        ctx.reconnect(max_timeout=1500, force_discovery=True)  # 25 * 60 = 1500
+        ctx.reconnect(max_timeout=3600, force_discovery=True)  # 60 * 60 = 3600
 
     else:
         ctx.info("Keeping console connected")


### PR DESCRIPTION
Resolve issue #79 by extending the timeout for reconnect. The current timeout is 25 minutes, which may not be sufficient for routers with very large configuration. The new timeout is 60 minutes.